### PR TITLE
v2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## Version 2.0.4
+- 依存する Gradle のバージョンを更新
+- DataChannelをVersion 2.0.5に更新
+- テストプログラムのWebViewDataBusのインジェクション方式を自動から手動に変更
+
 ## Version 2.0.3
 DataChannelをVersion 2.0.4に更新
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ FunctionChannel の Android用の実装を提供します。
 ### gradle
 ```
 dependencies {
-	compile 'jp.co.dwango.cbb:function-channel:2.0.3'
+	compile 'jp.co.dwango.cbb:function-channel:2.0.4'
 }
 ```
 

--- a/app/src/main/java/jp/co/dwango/cbb/fc/test/MainActivity.java
+++ b/app/src/main/java/jp/co/dwango/cbb/fc/test/MainActivity.java
@@ -46,7 +46,7 @@ public class MainActivity extends AppCompatActivity {
 		FunctionChannel.logging(true);
 
 		// DataBusを用いるWebViewを指定してインスタンス化
-		final DataBus dataBus = new WebViewDataBus(this, webView);
+		final WebViewDataBus dataBus = new WebViewDataBus(this, webView, true);
 
 		// DataChannelを作成
 		final DataChannel dataChannel = new DataChannel(dataBus);
@@ -137,7 +137,7 @@ public class MainActivity extends AppCompatActivity {
 		});
 
 		// WebView へコンテンツをロード
-		webView.loadDataWithBaseURL("", loadTextFromAssert("html/index.html"), "text/html", "UTF-8", null);
+		webView.loadDataWithBaseURL("", loadTextFromAssert("html/index.html").replace("$(WEB-VIEW-DATA-BUS)", dataBus.getInjectJavaScript()), "text/html", "UTF-8", null);
 	}
 
 	private String loadTextFromAssert(String path) {

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 

--- a/function-channel/build.gradle
+++ b/function-channel/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
-def pomVersion = "2.0.3"
+def pomVersion = "2.0.4"
 
 buildscript {
     repositories {
@@ -39,7 +39,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     compile 'com.android.support:appcompat-v7:23.2.1'
-    compile 'jp.co.dwango.cbb:data-channel:2.0.4'
+    compile 'jp.co.dwango.cbb:data-channel:2.0.5'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.9.5'
     testCompile 'org.json:json:20140107'


### PR DESCRIPTION
- 依存する Gradle のバージョンを更新
- DataChannelをVersion 2.0.5に更新
- テストプログラムを実機で動作できるようにする（WebViewDataBusのインジェクション方式を自動から手動に変更）