### PR TITLE
update data-channel-android ro 2.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+## Version 2.0.5
+- data-channel-androidを2.0.6に更新
+
 ## Version 2.0.4
 - 依存する Gradle のバージョンを更新
 - DataChannelをVersion 2.0.5に更新

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ FunctionChannel の Android用の実装を提供します。
 ### gradle
 ```
 dependencies {
-	compile 'jp.co.dwango.cbb:function-channel:2.0.4'
+	compile 'jp.co.dwango.cbb:function-channel:2.0.5'
 }
 ```
 

--- a/function-channel/build.gradle
+++ b/function-channel/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.novoda.bintray-release'
-def pomVersion = "2.0.4"
+def pomVersion = "2.0.5"
 
 buildscript {
     repositories {
@@ -39,7 +39,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     compile 'com.android.support:appcompat-v7:23.2.1'
-    compile 'jp.co.dwango.cbb:data-channel:2.0.5'
+    compile 'jp.co.dwango.cbb:data-channel:2.0.6'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.9.5'
     testCompile 'org.json:json:20140107'


### PR DESCRIPTION
data-channel-android 2.0.6の取り込み
https://github.com/cross-border-bridge/data-channel-android/pull/6

- [x] data-channel-android2.0.6のpublish
- [x] data-channel-android2.0.6を取り込んでビルドが通る事の確認